### PR TITLE
bug fix

### DIFF
--- a/api/pvc-api.php
+++ b/api/pvc-api.php
@@ -24,7 +24,7 @@ class PVC_API
     public function rest_api_init() {
 
         foreach ( $this->rest_bases as $rest_base ) {
-            register_rest_route( $this->namespace, $rest_base . '/(?P<post_ids>[a-zA-Z0-9_]+)', array(
+            register_rest_route( $this->namespace, $rest_base . '/(?P<post_ids>([a-zA-Z0-9_]\,?)+)', array(
                 'methods'  => 'GET',
                 'callback' => array( $this, str_replace( '/', '', $rest_base ) . '_stats' ),
             ) );


### PR DESCRIPTION
The original REST endpoint seems unable to accept array-like params but in fact some function calls assume it does. This pr modifies the regex expression in the REST endpoint so that it accepts array-like params as expected.