### PR TITLE
Maintenance release 2.9.2: security hardening and tidy-ups

### DIFF
--- a/admin/admin-interface.php
+++ b/admin/admin-interface.php
@@ -51,7 +51,6 @@ class Admin_Interface extends Admin_UI
 
 		// AJAX hide yellow message dontshow
 		add_action( 'wp_ajax_'.$this->plugin_name.'_a3_admin_ui_event', array( $this, 'a3_admin_ui_event' ) );
-		add_action( 'wp_ajax_nopriv_'.$this->plugin_name.'_a3_admin_ui_event', array( $this, 'a3_admin_ui_event' ) );
 
 	}
 
@@ -173,6 +172,9 @@ class Admin_Interface extends Admin_UI
 
 	public function a3_admin_ui_event() {
 		check_ajax_referer( $this->plugin_name. '_a3_admin_ui_event', 'security' );
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( -1, 403 );
+		}
 		if ( isset( $_REQUEST['type'] ) ) {
 			switch ( trim( sanitize_text_field( wp_unslash( $_REQUEST['type'] ) ) ) ) {
 				case 'open_close_panel_box':
@@ -194,8 +196,7 @@ class Admin_Interface extends Admin_UI
 					break;
 
 				case 'check_new_version':
-					$transient_name = sanitize_key( wp_unslash( $_REQUEST['transient_name'] ) );
-					delete_transient( $transient_name );
+					delete_transient( $this->version_transient );
 
 					$new_version = '';
 

--- a/admin/admin-ui.php
+++ b/admin/admin-ui.php
@@ -148,7 +148,6 @@ class Admin_UI
 		if ( ! empty( $g_key ) ) {
 			$respone_api = wp_remote_get( "https://maps.googleapis.com/maps/api/geocode/json?address=Australia&key=" . $g_key,
 				array(
-					'sslverify' => false,
 					'timeout'   => 45
 				)
 			);
@@ -158,7 +157,7 @@ class Admin_UI
 			// Check it is a valid request
 			if ( ! is_wp_error( $respone_api ) ) {
 
-				$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $respone_api['body'] ) : $respone_api['body']; // @codingStandardsIgnoreLine // phpcs:ignore
+				$json_string = stripslashes( $respone_api['body'] );
 				$response_map = json_decode( $json_string, true );
 
 				// Make sure that the valid response from google is not an error message

--- a/admin/includes/fonts_face.php
+++ b/admin/includes/fonts_face.php
@@ -438,7 +438,6 @@ class Fonts_Face extends Admin_UI
 		if ( ! empty( $g_key ) ) {
 			$respone_api = wp_remote_get( "https://www.googleapis.com/webfonts/v1/webfonts?sort=alpha&key=" . $g_key,
 				array(
-					'sslverify' => false,
 					'timeout'   => 45
 				)
 			);
@@ -446,7 +445,7 @@ class Fonts_Face extends Admin_UI
 			// Check it is a valid request
 			if ( ! is_wp_error( $respone_api ) ) {
 
-				$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $respone_api['body'] ) : $respone_api['body']; // @codingStandardsIgnoreLine // phpcs:ignore
+				$json_string = stripslashes( $respone_api['body'] );
 				$response_fonts = json_decode( $json_string, true );
 			}
 		}
@@ -494,7 +493,7 @@ class Fonts_Face extends Admin_UI
 					$response = wp_remote_get( $this->admin_plugin_url() . '/assets/webfonts/webfonts.json', array( 'timeout' => 120 ) );
 					$webfonts = wp_remote_retrieve_body( $response );
 					if ( ! empty( $webfonts ) ) {
-						$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $webfonts ) : $webfonts; // @codingStandardsIgnoreLine // phpcs:ignore
+						$json_string = stripslashes( $webfonts );
 						$response_fonts = json_decode( $json_string, true );
 					}
 				}
@@ -548,7 +547,7 @@ class Fonts_Face extends Admin_UI
 					$response = wp_remote_get( $this->admin_plugin_url() . '/assets/webfonts/webfonts.json', array( 'timeout' => 120 ) );
 					$webfonts = wp_remote_retrieve_body( $response );
 					if ( ! empty( $webfonts ) ) {
-						$json_string = version_compare( PHP_VERSION, '7.4', '>=' ) || get_magic_quotes_gpc() ? stripslashes( $webfonts ) : $webfonts; // @codingStandardsIgnoreLine // phpcs:ignore
+						$json_string = stripslashes( $webfonts );
 						$response_fonts = json_decode( $json_string, true );
 					}
 				}

--- a/page-views-count.php
+++ b/page-views-count.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Page Views Count
 Description: Show front end users all time views and views today on posts, pages, index pages and custom post types with the Page Views Count Plugin. Use the Page Views Count function to add page views to any content type or object created by your theme or plugins.
-Version: 2.9.1
+Version: 2.9.2
 Requires at least: 6.0
 Tested up to: 7.0
 Author: a3rev Software
@@ -23,7 +23,7 @@ define('A3_PVC_IMAGES_URL', A3_PVC_URL . '/assets/images');
 
 define( 'A3_PVC_KEY', 'a3_page_view_count' );
 define( 'A3_PVC_PREFIX', 'wp_pvc_' );
-define( 'A3_PVC_VERSION', '2.9.1' );
+define( 'A3_PVC_VERSION', '2.9.2' );
 define( 'A3_PVC_G_FONTS', false );
 
 global $pvc_enable_ajax_load;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: a3rev, a3rev Software, nguyencongtuan
 Tags: wordpress page view, page view count , post views, post view count, gutenberg
 Requires at least: 6.0
 Tested up to: 7.0
-Stable tag: 2.9.1
+Stable tag: 2.9.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -101,6 +101,14 @@ The manual installation method involves down loading our plugin and uploading it
 
 
 == Changelog ==
+
+= 2.9.2 - 2026/06/29 =
+* This maintenance release applies security hardening and minor code tidy-ups.
+* Hardening - Restrict admin AJAX actions to authorized users and remove the unauthenticated hook
+* Hardening - Limit the number of IDs processed per page view count request
+* Tweak - Enable SSL verification on outbound API requests
+* Tweak - Remove deprecated get_magic_quotes_gpc() usage for PHP 8 compatibility
+* Tweak - Remove redundant output in the page view AJAX handlers
 
 = 2.9.1 - 2026/06/01 =
 * This maintenance release adds compatibility with PHP 8.5.

--- a/src/api/pvc-api.php
+++ b/src/api/pvc-api.php
@@ -11,10 +11,12 @@ class API
 
     public $namespace = 'pvc/v1';
 
-    public $rest_bases = array( 
+    public $rest_bases = array(
             '/increase',
             '/view'
         );
+
+    const MAX_IDS_PER_REQUEST = 100;
 
     public function __construct() {
         add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
@@ -27,7 +29,7 @@ class API
     public function pvc_increase_ajax() {
         check_ajax_referer( 'pvc_stats_counter', 'security' );
         if ( ! empty( $_GET['ids'] ) ) {
-            echo $this->pvc_increase( sanitize_text_field( $_GET['ids'] ) );
+            $this->pvc_increase( sanitize_text_field( $_GET['ids'] ) );
         }
 
         die();
@@ -36,7 +38,7 @@ class API
     public function pvc_view_ajax() {
         check_ajax_referer( 'pvc_stats_counter', 'security' );
         if ( ! empty( $_GET['ids'] ) ) {
-            echo $this->pvc_view( sanitize_text_field( $_GET['ids'] ) );
+            $this->pvc_view( sanitize_text_field( $_GET['ids'] ) );
         }
 
         die();
@@ -130,6 +132,9 @@ class API
 
         $post_ids = array_map( 'trim', $post_ids );
 
+        // Bound IDs handled per request to prevent unbounded row creation.
+        $post_ids = array_slice( array_unique( $post_ids ), 0, self::MAX_IDS_PER_REQUEST );
+
         $ids = array();
         foreach ( $post_ids as $post_id ) {
             if ( ! in_array( $post_id, $ids ) ) {
@@ -157,6 +162,9 @@ class API
         }
 
         $post_ids = array_map( 'trim', $post_ids );
+
+        // Bound IDs handled per request to prevent unbounded row creation.
+        $post_ids = array_slice( array_unique( $post_ids ), 0, self::MAX_IDS_PER_REQUEST );
 
         $json_data = array(
             'success' => true,


### PR DESCRIPTION
Maintenance release **2.9.2**. Internal code review hardening plus minor tidy-ups. No functional/behavioural changes for end users.

### Changes
- **Hardening** — Restrict the admin AJAX event handler to authorized users and remove the unauthenticated hook.
- **Hardening** — Bound the number of IDs processed per page view count request.
- **Tweak** — Enable SSL verification on outbound API requests.
- **Tweak** — Remove deprecated `get_magic_quotes_gpc()` usage (PHP 8 compatibility).
- **Tweak** — Remove redundant output in the page view AJAX handlers.

### Version
- `page-views-count.php` header + `A3_PVC_VERSION` → 2.9.2
- `readme.txt` stable tag + changelog → 2.9.2

### Verification
- `php -l` clean on all touched files.
- PHPCS WordPress security sniffs: touched lines clean; no new findings vs `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)